### PR TITLE
fix(search): fixed ClientSearchRaw to return GenericResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - added the field `index` in the search_request
 - added source in the OS response body - [PDT-10](https://intruderlabs.atlassian.net/browse/PDT-10)
 
+### Fixed
+
+- fixed `ClientSearchRaw` to return `GenericResponse`
+
 ### Changed
 
 - corrected the error deserialization when it's not found response

--- a/main/client_interface.go
+++ b/main/client_interface.go
@@ -17,5 +17,5 @@ type ClientInterface interface {
 	Initialize(indexName string, properties entities.IndexTemplateMappingProperties) error
 	ClientSearchRequest(queryPaginationRequest requests.OsSearchRequest) (responses.OsResponse, []errors.GenericError)
 	ClientIdSearchRequest(index, id string) (responses.OsResponse, []errors.GenericError)
-	ClientSearchRaw(request requests.OsSearchRequest) (responses.OsResponse, []errors.GenericError)
+	ClientSearchRaw(request requests.OsSearchRequest) (dresponses.GenericResponse, []errors.GenericError)
 }


### PR DESCRIPTION
This pull request includes changes to fix a bug in the `ClientSearchRaw` method and update the `CHANGELOG.md` file accordingly. The most important changes include fixing the `ClientSearchRaw` method to return the correct response type and adding a new section to the changelog to document this fix.

Bug Fixes:

* [`main/client_interface.go`](diffhunk://#diff-c016aa6e89094ae404fa86c9e8d8eb687caf8cd78a212cdd0ab1132b731f3e41L20-R20): Fixed the `ClientSearchRaw` method to return `GenericResponse` instead of `OsResponse`.

Documentation:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR28-R31): Added a new "Fixed" section to document the fix for the `ClientSearchRaw` method.